### PR TITLE
Update requirements.txt - fix error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ imageio
 imageio-ffmpeg
 ftfy
 bs4
+huggingface-hub==0.25.2


### PR DESCRIPTION
huggingface-hub==0.26.1 throws error
ImportError: cannot import name 'cached_download' from 'huggingface_hub'. 

Hence version fixed to 0.25.2.